### PR TITLE
Fix package

### DIFF
--- a/company-shell.el
+++ b/company-shell.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2015 Alexander Miller
 
 ;; Author: Alexander Miller <alexanderm@web.de>
-;; Package-Requires: ((company) (dash) (cl-lib))
+;; Package-Requires: ((company "0.8.12") (dash "2.12.0") (cl-lib "0.5"))
 ;; Homepage: https://github.com/Alexander-Miller/company-shell
 ;; Version: 1.0
 ;; Keywords: company, shell

--- a/company-shell.el
+++ b/company-shell.el
@@ -93,7 +93,7 @@ All modes not on this list will be ignored. Set value to nil to enable company-s
    (let ((man-page (shell-command-to-string (format "man %s" arg))))
      (if (or
           (null man-page)
-          (string-empty-p man-page)
+          (string= man-page "")
           (string-prefix-p "No manual entry" man-page))
          (or
           (shell-command-to-string (format "%s --help" arg))


### PR DESCRIPTION
- Specify minimum package version of dependency for packaging convention
- Replace `string-empty-p` for older Emacs. `string-empty-p` was introduced at Emacs 24.4 and `subr-x` has to be loaded for using it.
