### PR TITLE
Correctly build fish cache when shell-file-name is not fish

### DIFF
--- a/company-shell.el
+++ b/company-shell.el
@@ -175,11 +175,10 @@ Build it if necessary."
 
 (defun company-shell--build-fish-cache ()
   "Build the list of all fish shell completions."
-  (when (executable-find "fish")
+  (when-let ((shell-file-name (executable-find "fish")))
     (setq company-shell--fish-cache
           (-flatten (--map
                      (-> it
-                         (format "fish -c \"%s\"")
                          (shell-command-to-string)
                          (split-string "\n")
                          (sort #'string-lessp))


### PR DESCRIPTION
Currently, `company-shell--fish-cache` is not correctly build when Emacs is launch from bash shell. The problem can be highlight using the following elisp script (named `test-fish-completion.el` in the following):
```emacs-lisp
;; company-shell installation
(require 'package)

(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)

(package-initialize)
(unless package-archive-contents
  (package-refresh-contents))

(unless (package-installed-p 'use-package)
  (package-install 'company-shell))


;; test function
(require 'company-shell)
(defun test-fish-completion-cache ()
  (message "- environment $SHELL value: %s" (getenv "SHELL"))
  (message "- `shell-file-name' value: %s" shell-file-name)
  (company-shell--build-fish-cache)
  (message "- first elements of `company-shell--fish-cache': %s\n" (butlast company-shell--fish-cache (- (length company-shell--fish-cache) 10))))


;; test cases
(message "== Test with default shell-file-name ==")
(test-fish-completion-cache)

(setq shell-file-name "/bin/bash")
(message "== Test with shell-file-name forced to %s ==" shell-file-name)
(test-fish-completion-cache)

(setq shell-file-name (executable-find "fish"))
(message "== Test with shell-file-name forced to %s ==" shell-file-name)
(test-fish-completion-cache)
```

When testing from bash shell, we get the following output:
```
LANG=C emacs -Q --script test-fish-completion.el
Setting `package-selected-packages' temporarily since "emacs -q" would overwrite customizations
`company-shell' is already installed
== Test with default shell-file-name ==
- environment $SHELL value: /bin/bash
- `shell-file-name' value: /bin/bash
- first elements of `company-shell--fish-cache': ( /bin/bash: line 1: functions: command not found  /bin/bash: line 1: builtin: -n: invalid option builtin: usage: builtin [shell-builtin [arg ...]])

== Test with shell-file-name forced to /bin/bash ==
- environment $SHELL value: /bin/bash
- `shell-file-name' value: /bin/bash
- first elements of `company-shell--fish-cache': ( /bin/bash: line 1: functions: command not found  /bin/bash: line 1: builtin: -n: invalid option builtin: usage: builtin [shell-builtin [arg ...]])

== Test with shell-file-name forced to /usr/bin/fish ==
- environment $SHELL value: /bin/bash
- `shell-file-name' value: /usr/bin/fish
- first elements of `company-shell--fish-cache': ( N_ __fish_any_arg_in __fish_anypython __fish_append __fish_apropos __fish_argcomplete_complete __fish_cancel_commandline __fish_commandline_is_singlequoted __fish_complete_atool_archive_contents)
```

And the following from fish shell:
```
LANG=C emacs -Q --script test-fish-completion.el
Setting `package-selected-packages' temporarily since "emacs -q" would overwrite customizations
`company-shell' is already installed
== Test with default shell-file-name ==
- environment $SHELL value: /usr/bin/fish
- `shell-file-name' value: /usr/bin/fish
- first elements of `company-shell--fish-cache': ( N_ __fish_any_arg_in __fish_anypython __fish_append __fish_apropos __fish_argcomplete_complete __fish_cancel_commandline __fish_commandline_is_singlequoted __fish_complete_atool_archive_contents)

== Test with shell-file-name forced to /bin/bash ==
- environment $SHELL value: /usr/bin/fish
- `shell-file-name' value: /bin/bash
- first elements of `company-shell--fish-cache': ( /bin/bash: line 1: functions: command not found  /bin/bash: line 1: builtin: -n: invalid option builtin: usage: builtin [shell-builtin [arg ...]])

== Test with shell-file-name forced to /usr/bin/fish ==
- environment $SHELL value: /usr/bin/fish
- `shell-file-name' value: /usr/bin/fish
- first elements of `company-shell--fish-cache': ( N_ __fish_any_arg_in __fish_anypython __fish_append __fish_apropos __fish_argcomplete_complete __fish_cancel_commandline __fish_commandline_is_singlequoted __fish_complete_atool_archive_contents)
```

This PR fixes the issue by making `company-shell--build-fish-cache` function independent of pre-filled `shell-file-name` (configured by the user or default value computed by Emacs).